### PR TITLE
EtlStats reporter

### DIFF
--- a/src/delphyne/model/etl_stats/etl_stats_reporter.py
+++ b/src/delphyne/model/etl_stats/etl_stats_reporter.py
@@ -38,15 +38,13 @@ class EtlStatsReporter:
 
             self._log_sources()
 
-            vocab_transformations = [t for t in self.stats.transformations
-                                     if t.is_vocab_only and not t.is_empty]
+            vocab_transformations = [t for t in self.stats.transformations if t.is_vocab_only]
             if vocab_transformations:
                 logger.info(f'Vocabulary updates: {len(vocab_transformations)} (total time: '
                             f'{self.stats.get_total_duration(vocab_transformations)})')
                 self._log_transformations(vocab_transformations)
 
-            cdm_transformations = [t for t in self.stats.transformations
-                                   if not t.is_vocab_only and not t.is_empty]
+            cdm_transformations = [t for t in self.stats.transformations if not t.is_vocab_only]
             if cdm_transformations:
                 logger.info(f'CDM transformations: {len(cdm_transformations)} (total time: '
                             f'{self.stats.get_total_duration(cdm_transformations)})')
@@ -71,7 +69,8 @@ class EtlStatsReporter:
         if successful_transformations:
             logger.info(f'Successful transformations ({len(successful_transformations)}):')
             for transformation in successful_transformations:
-                self._log_transformation_counts(transformation)
+                if not transformation.is_empty:
+                    self._log_transformation_counts(transformation)
 
         failed_transformations = [t for t in transformations if not t.query_success]
         if failed_transformations:

--- a/tests/python/model/etl_stats/conftest.py
+++ b/tests/python/model/etl_stats/conftest.py
@@ -1,0 +1,19 @@
+from collections import Counter
+from datetime import datetime
+
+from src.delphyne.model.etl_stats import EtlTransformation
+
+
+def get_etltransformation(name: str, **kwargs) -> EtlTransformation:
+    default_params = {
+        'name': name,
+        'start': datetime(year=2025, month=1, day=1, hour=1),
+        'end': datetime(year=2025, month=1, day=1, hour=2),
+        'query_success': True,
+        'insertion_counts': Counter(),
+        'update_counts': Counter(),
+        'deletion_counts': Counter(),
+    }
+    # Replace default values with those provided, if any
+    final_params = {k: v if k not in kwargs else kwargs[k] for k, v in default_params.items()}
+    return EtlTransformation(**final_params)

--- a/tests/python/model/etl_stats/test_etl_stats.py
+++ b/tests/python/model/etl_stats/test_etl_stats.py
@@ -2,8 +2,9 @@ from collections import Counter
 from datetime import datetime, timedelta
 
 import pytest
-
 from src.delphyne.model.etl_stats import EtlStats, EtlSource, EtlTransformation
+
+from tests.python.model.etl_stats.conftest import get_etltransformation
 
 
 @pytest.fixture(scope="module")
@@ -47,21 +48,6 @@ def test_etltransformation_to_dict(etl_transformation: EtlTransformation):
         'update_counts': 'table1:10',
         'deletion_counts': None,
     }
-
-
-def get_etltransformation(name: str, **kwargs) -> EtlTransformation:
-    default_params = {
-        'name': name,
-        'start': datetime(year=2025, month=1, day=1, hour=1),
-        'end': datetime(year=2025, month=1, day=1, hour=2),
-        'query_success': True,
-        'insertion_counts': Counter(),
-        'update_counts': Counter(),
-        'deletion_counts': Counter(),
-    }
-    # Replace default values with those provided, if any
-    final_params = {k: v if k not in kwargs else kwargs[k] for k, v in default_params.items()}
-    return EtlTransformation(**final_params)
 
 
 def test_transformation_is_vocab_only():

--- a/tests/python/model/etl_stats/test_etl_stats_reporter.py
+++ b/tests/python/model/etl_stats/test_etl_stats_reporter.py
@@ -1,0 +1,53 @@
+import logging
+from collections import Counter
+
+import pytest
+from src.delphyne.model.etl_stats import EtlStats, EtlTransformation, EtlStatsReporter
+
+from tests.python.model.etl_stats.conftest import get_etltransformation
+
+logger = logging.getLogger('test_logger')
+logger.setLevel(logging.DEBUG)
+
+
+@pytest.fixture(scope='function')
+def reporter_summary_output(request, caplog) -> str:
+    """Get summary report for the given EtlTransformation."""
+    stats = EtlStats()
+    transformation: EtlTransformation = request.param
+    stats.add_transformation(transformation)
+    reporter = EtlStatsReporter(etl_stats=stats)
+    with caplog.at_level(logging.INFO):
+        reporter.log_summary()
+    return caplog.text
+
+
+@pytest.mark.parametrize('reporter_summary_output',
+                         [get_etltransformation(name='empty_successful')],
+                         indirect=True)
+def test_empty_successful(reporter_summary_output: str):
+    assert 'empty_successful' not in reporter_summary_output
+
+
+@pytest.mark.parametrize('reporter_summary_output',
+                         [get_etltransformation(name='empty_unsuccessful', query_success=False)],
+                         indirect=True)
+def test_empty_unsuccessful(reporter_summary_output: str):
+    assert 'empty_unsuccessful' in reporter_summary_output
+
+
+@pytest.mark.parametrize('reporter_summary_output',
+                         [get_etltransformation(name='with_records_successful',
+                                                insertion_counts=Counter({'person': 5}))],
+                         indirect=True)
+def test_with_records_successful(reporter_summary_output: str):
+    assert 'with_records_successful' in reporter_summary_output
+
+
+@pytest.mark.parametrize('reporter_summary_output',
+                         [get_etltransformation(name='with_records_unsuccessful',
+                                                query_success=False,
+                                                insertion_counts=Counter({'observation': 5}))],
+                         indirect=True)
+def test_with_records_unsuccessful(reporter_summary_output: str):
+    assert 'with_records_unsuccessful' in reporter_summary_output


### PR DESCRIPTION
- Fixes #90 
- Add basic tests on what `EtlTransformation` instances are expected to end up in the summary report.