### PR TITLE
Case insensitive file check

### DIFF
--- a/src/delphyne/model/custom_vocab/base_manager/base_concept_manager.py
+++ b/src/delphyne/model/custom_vocab/base_manager/base_concept_manager.py
@@ -27,17 +27,18 @@ class BaseConceptManager:
         logging.info(f'Dropping old custom concepts: '
                      f'{True if vocab_ids else False}')
 
-        if vocab_ids:
+        if not vocab_ids:
+            return
 
-            transformation_metadata = EtlTransformation(name='drop_concepts')
+        transformation_metadata = EtlTransformation(name='drop_concepts')
 
-            with self._db.session_scope(metadata=transformation_metadata) as session:
-                session.query(self._cdm.Concept) \
-                    .filter(self._cdm.Concept.vocabulary_id.in_(vocab_ids)) \
-                    .delete(synchronize_session=False)
+        with self._db.session_scope(metadata=transformation_metadata) as session:
+            session.query(self._cdm.Concept) \
+                .filter(self._cdm.Concept.vocabulary_id.in_(vocab_ids)) \
+                .delete(synchronize_session=False)
 
-                transformation_metadata.end_now()
-                etl_stats.add_transformation(transformation_metadata)
+            transformation_metadata.end_now()
+            etl_stats.add_transformation(transformation_metadata)
 
     def _load_custom_concepts(self, vocab_ids: Set[str], valid_prefixes: Set[str]) -> None:
         # Load concept_ids associated with a set of custom
@@ -46,62 +47,63 @@ class BaseConceptManager:
         logging.info(f'Loading new custom concept_ids: '
                      f'{True if vocab_ids else False}')
 
-        if vocab_ids:
+        if not vocab_ids:
+            return
 
-            unique_concepts_check = set()
+        unique_concepts_check = set()
 
-            for concept_file in self._custom_concept_files:
+        for concept_file in self._custom_concept_files:
 
-                transformation_metadata = EtlTransformation(name=f'load_{concept_file.stem}')
+            transformation_metadata = EtlTransformation(name=f'load_{concept_file.stem}')
 
-                file_prefix = get_file_prefix(concept_file, 'concept')
-                invalid_vocabs = set()
+            file_prefix = get_file_prefix(concept_file, 'concept')
+            invalid_vocabs = set()
 
-                with self._db.session_scope(metadata=transformation_metadata) as session, \
-                        concept_file.open('r') as f_in:
-                    rows = csv.DictReader(f_in, delimiter='\t')
-                    records = []
+            with self._db.session_scope(metadata=transformation_metadata) as session, \
+                    concept_file.open('r') as f_in:
+                rows = csv.DictReader(f_in, delimiter='\t')
+                records = []
 
-                    for row in rows:
-                        concept_id = row['concept_id']
-                        vocabulary_id = row['vocabulary_id']
+                for row in rows:
+                    concept_id = row['concept_id']
+                    vocabulary_id = row['vocabulary_id']
 
-                        # quality checks
-                        if int(concept_id) < 2000000000:
-                            raise ValueError(
-                                f'{concept_file.name} must have concept_ids starting at '
-                                f'2\'000\'000\'000 (2B+ convention)')
-                        if concept_id in unique_concepts_check:
-                            raise ValueError(
-                                f'concept {concept_id} has duplicates across one or multiple '
-                                f'files')
+                    # quality checks
+                    if int(concept_id) < 2000000000:
+                        raise ValueError(
+                            f'{concept_file.name} must have concept_ids starting at '
+                            f'2\'000\'000\'000 (2B+ convention)')
+                    if concept_id in unique_concepts_check:
+                        raise ValueError(
+                            f'concept {concept_id} has duplicates across one or multiple '
+                            f'files')
 
-                        if vocabulary_id in vocab_ids:
-                            records.append(self._cdm.Concept(
-                                concept_id=row['concept_id'],
-                                concept_name=row['concept_name'],
-                                domain_id=row['domain_id'],
-                                vocabulary_id=row['vocabulary_id'],
-                                concept_class_id=row['concept_class_id'],
-                                standard_concept=row['standard_concept'],
-                                concept_code=row['concept_code'],
-                                valid_start_date=row['valid_start_date'],
-                                valid_end_date=row['valid_end_date'],
-                                invalid_reason=row['invalid_reason']
-                            ))
+                    if vocabulary_id in vocab_ids:
+                        records.append(self._cdm.Concept(
+                            concept_id=row['concept_id'],
+                            concept_name=row['concept_name'],
+                            domain_id=row['domain_id'],
+                            vocabulary_id=row['vocabulary_id'],
+                            concept_class_id=row['concept_class_id'],
+                            standard_concept=row['standard_concept'],
+                            concept_code=row['concept_code'],
+                            valid_start_date=row['valid_start_date'],
+                            valid_end_date=row['valid_end_date'],
+                            invalid_reason=row['invalid_reason']
+                        ))
 
-                        # if file prefix is valid vocab_id,
-                        # vocabulary_ids in file should match it.
-                        # comparison is case-insensitive.
-                        vocabs_lowercase = {vocab.lower() for vocab in valid_prefixes}
-                        if file_prefix in vocabs_lowercase and vocabulary_id.lower() != file_prefix:
-                            invalid_vocabs.add(vocabulary_id)
+                    # if file prefix is valid vocab_id,
+                    # vocabulary_ids in file should match it.
+                    # comparison is case-insensitive.
+                    vocabs_lowercase = {vocab.lower() for vocab in valid_prefixes}
+                    if file_prefix in vocabs_lowercase and vocabulary_id.lower() != file_prefix:
+                        invalid_vocabs.add(vocabulary_id)
 
-                    session.add_all(records)
+                session.add_all(records)
 
-                    transformation_metadata.end_now()
-                    etl_stats.add_transformation(transformation_metadata)
+                transformation_metadata.end_now()
+                etl_stats.add_transformation(transformation_metadata)
 
-                if invalid_vocabs:
-                    logging.warning(f'{concept_file.name} contains vocabulary_ids '
-                                    f'that do not match file prefix')
+            if invalid_vocabs:
+                logging.warning(f'{concept_file.name} contains vocabulary_ids '
+                                f'that do not match file prefix')

--- a/src/delphyne/model/custom_vocab/base_manager/base_concept_manager.py
+++ b/src/delphyne/model/custom_vocab/base_manager/base_concept_manager.py
@@ -93,7 +93,7 @@ class BaseConceptManager:
                         # if file prefix is valid vocab_id,
                         # vocabulary_ids in file should match it.
                         # comparison is case-insensitive.
-                        vocabs_lowercase = valid_prefixes.lower()
+                        vocabs_lowercase = { vocab.lower() for vocab in valid_prefixes }
                         if file_prefix in vocabs_lowercase and vocabulary_id.lower() != file_prefix:
                             invalid_vocabs.add(vocabulary_id)
 

--- a/src/delphyne/model/custom_vocab/base_manager/base_concept_manager.py
+++ b/src/delphyne/model/custom_vocab/base_manager/base_concept_manager.py
@@ -54,7 +54,7 @@ class BaseConceptManager:
 
                 transformation_metadata = EtlTransformation(name=f'load_{concept_file.stem}')
 
-                prefix = get_file_prefix(concept_file, 'concept')
+                file_prefix = get_file_prefix(concept_file, 'concept')
                 invalid_vocabs = set()
 
                 with self._db.session_scope(metadata=transformation_metadata) as session, \
@@ -90,9 +90,11 @@ class BaseConceptManager:
                                 invalid_reason=row['invalid_reason']
                             ))
 
-                        # if prefix is valid vocab_id,
-                        # vocabulary_ids in file should match it
-                        if prefix in valid_prefixes and vocabulary_id != prefix:
+                        # if file prefix is valid vocab_id,
+                        # vocabulary_ids in file should match it.
+                        # comparison is case-insensitive.
+                        vocabs_lowercase = valid_prefixes.lower()
+                        if file_prefix in vocabs_lowercase and vocabulary_id.lower() != file_prefix:
                             invalid_vocabs.add(vocabulary_id)
 
                     session.add_all(records)

--- a/src/delphyne/model/custom_vocab/base_manager/base_concept_manager.py
+++ b/src/delphyne/model/custom_vocab/base_manager/base_concept_manager.py
@@ -93,7 +93,7 @@ class BaseConceptManager:
                         # if file prefix is valid vocab_id,
                         # vocabulary_ids in file should match it.
                         # comparison is case-insensitive.
-                        vocabs_lowercase = { vocab.lower() for vocab in valid_prefixes }
+                        vocabs_lowercase = {vocab.lower() for vocab in valid_prefixes}
                         if file_prefix in vocabs_lowercase and vocabulary_id.lower() != file_prefix:
                             invalid_vocabs.add(vocabulary_id)
 

--- a/src/delphyne/model/custom_vocab/base_manager/base_vocab_manager.py
+++ b/src/delphyne/model/custom_vocab/base_manager/base_vocab_manager.py
@@ -194,7 +194,7 @@ class BaseVocabManager:
                     # if file prefix is valid vocab_id,
                     # vocabulary_ids in file should match it.
                     # comparison is case-insensitive.
-                    vocabs_lowercase = self.vocabs_from_disk.lower()
+                    vocabs_lowercase = { vocab.lower() for vocab in self.vocabs_from_disk }
                     if file_prefix in vocabs_lowercase and vocabulary_id.lower() != file_prefix:
                         invalid_vocabs.add(vocabulary_id)
 

--- a/src/delphyne/model/custom_vocab/base_manager/base_vocab_manager.py
+++ b/src/delphyne/model/custom_vocab/base_manager/base_vocab_manager.py
@@ -167,7 +167,7 @@ class BaseVocabManager:
 
         for vocab_file in self._custom_vocab_files:
 
-            prefix = get_file_prefix(vocab_file, 'vocabulary')
+            file_prefix = get_file_prefix(vocab_file, 'vocabulary')
             invalid_vocabs = set()
 
             transformation_metadata = EtlTransformation(name=f'load_{vocab_file.stem}')
@@ -191,9 +191,11 @@ class BaseVocabManager:
                     else:
                         ignored_vocabs.update([vocabulary_id])
 
-                    # if prefix is valid vocab_id,
-                    # vocabulary_ids in file should match it
-                    if prefix in self.vocabs_from_disk and vocabulary_id != prefix:
+                    # if file prefix is valid vocab_id,
+                    # vocabulary_ids in file should match it.
+                    # comparison is case-insensitive.
+                    vocabs_lowercase = self.vocabs_from_disk.lower()
+                    if file_prefix in vocabs_lowercase and vocabulary_id.lower() != file_prefix:
                         invalid_vocabs.add(vocabulary_id)
 
                 session.add_all(records)

--- a/src/delphyne/model/custom_vocab/base_manager/base_vocab_manager.py
+++ b/src/delphyne/model/custom_vocab/base_manager/base_vocab_manager.py
@@ -194,7 +194,7 @@ class BaseVocabManager:
                     # if file prefix is valid vocab_id,
                     # vocabulary_ids in file should match it.
                     # comparison is case-insensitive.
-                    vocabs_lowercase = { vocab.lower() for vocab in self.vocabs_from_disk }
+                    vocabs_lowercase = {vocab.lower() for vocab in self.vocabs_from_disk}
                     if file_prefix in vocabs_lowercase and vocabulary_id.lower() != file_prefix:
                         invalid_vocabs.add(vocabulary_id)
 

--- a/src/delphyne/model/custom_vocab/base_manager/base_vocab_manager.py
+++ b/src/delphyne/model/custom_vocab/base_manager/base_vocab_manager.py
@@ -140,17 +140,18 @@ class BaseVocabManager:
         logging.info(f'Dropping old custom vocabulary versions: '
                      f'{True if vocabs_to_drop else False}')
 
-        if vocabs_to_drop:
+        if not vocabs_to_drop:
+            return
 
-            transformation_metadata = EtlTransformation(name='drop_concepts')
+        transformation_metadata = EtlTransformation(name='drop_concepts')
 
-            with self._db.session_scope(metadata=transformation_metadata) as session:
-                session.query(self._cdm.Vocabulary) \
-                    .filter(self._cdm.Vocabulary.vocabulary_id.in_(vocabs_to_drop)) \
-                    .delete(synchronize_session=False)
+        with self._db.session_scope(metadata=transformation_metadata) as session:
+            session.query(self._cdm.Vocabulary) \
+                .filter(self._cdm.Vocabulary.vocabulary_id.in_(vocabs_to_drop)) \
+                .delete(synchronize_session=False)
 
-                transformation_metadata.end_now()
-                etl_stats.add_transformation(transformation_metadata)
+            transformation_metadata.end_now()
+            etl_stats.add_transformation(transformation_metadata)
 
     def _load_custom_vocabs(self) -> None:
         # Load new and updated custom vocabularies to the database

--- a/src/delphyne/model/custom_vocab/custom_vocab_loader.py
+++ b/src/delphyne/model/custom_vocab/custom_vocab_loader.py
@@ -37,7 +37,7 @@ class CustomVocabLoader(BaseVocabManager, BaseClassManager, BaseConceptManager):
         # Get custom vocab files for a specific vocabulary target table
         # based on the file name conventions (e.g. "concept").
         custom_table_files = get_all_files_in_dir(CUSTOM_VOCAB_DIR)
-        return [f for f in custom_table_files if f.stem.endswith(omop_table)]
+        return [f for f in custom_table_files if f.stem.lower().endswith(omop_table)]
 
     def _update_custom_file_list(self, file_list: List[Path], omop_table: str) -> List[Path]:
         # Check if file has either a valid prefix (matching a

--- a/src/delphyne/model/raw_sql_wrapper.py
+++ b/src/delphyne/model/raw_sql_wrapper.py
@@ -39,8 +39,9 @@ class RawSqlWrapper:
         """
         Executes raw SQL file.
 
-        :param file_path: relative SQL file path inside the directory for
-            SQL transformations (the root will be automatically added).
+        :param file_path: relative SQL file path inside the directory
+            for SQL transformations
+            (the root will be automatically added).
         :return: None
         """
         file_path = SQL_TRANSFORMATIONS_DIR / file_path

--- a/src/delphyne/util/io.py
+++ b/src/delphyne/util/io.py
@@ -28,7 +28,20 @@ def get_all_files_in_dir(directory: Path) -> List[Path]:
 
 
 def get_file_prefix(path: Path, suffix: str) -> Optional[str]:
-    stem = path.stem
+    """
+    Extracts the part of the file name preceding the provided suffix.
+
+    :param path: File path
+    :param suffix: String to be matched to the file name. The match only
+        succeeds if the suffix is immediately preceding the file
+        extension, and separated by previous characters by a dash ('_').
+        The file name and prefix are both converted to lowercase before
+        the matching is performed.
+
+    :return: str (lowercase) or None
+    """
+    suffix = suffix.lower()
+    stem = path.stem.lower()
     if stem.endswith('_' + suffix):
         prefix = stem.rsplit('_' + suffix, 1)[0]
         return prefix
@@ -49,6 +62,7 @@ def file_has_valid_prefix(path: Path, suffix: str,
     If the prefix is recognized but not in the list to parse,
     the file should be ignored (returns False).
     valid_prefixes should be a subset of all_prefixes.
+    All comparisons are performed in lowercase.
 
     :param path: Path
     :param suffix: str
@@ -57,6 +71,11 @@ def file_has_valid_prefix(path: Path, suffix: str,
 
     :return: bool
     """
+
+    # convert prefixes to lowercase
+    valid_prefixes = {prefix.lower() for prefix in valid_prefixes}
+    all_prefixes = {prefix.lower() for prefix in all_prefixes}
+
     file_prefix = get_file_prefix(path, suffix)
     if file_prefix in valid_prefixes:
         return True

--- a/src/delphyne/util/io.py
+++ b/src/delphyne/util/io.py
@@ -29,7 +29,7 @@ def get_all_files_in_dir(directory: Path) -> List[Path]:
 
 def get_file_prefix(path: Path, suffix: str) -> Optional[str]:
     """
-    Extracts the part of the file name preceding the provided suffix.
+    Extract the part of the file name preceding the provided suffix.
 
     :param path: File path
     :param suffix: String to be matched to the file name. The match only


### PR DESCRIPTION
Closes #95

Makes comparison of custom vocabulary file names case-insensitive. 
Both prefixes and suffixes will be checked against vocabulary ids and table names (respectively) in lowercase.

Comparisons between vocabulary ids already loaded to the database and vocabulary ids provided in the files remain case-sensitive.

..Or do you think making the prefix check case-insensitive is a bad idea? 🤔 Debatable