### PR TITLE
Nox lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,19 @@
+name: lint
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          pip install nox
+      - name: Lint with flake8 in nox session
+        run: |
+          nox -s lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,3 +1,5 @@
+# This workflow will install Python 3.8 + dependencies and run a nox lint session
+
 name: lint
 
 on: [push, pull_request]

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,4 +1,5 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# This workflow will install Python dependencies, run tests with a variety of Python versions
+# and calculate/publish coverage
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
 name: build

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -21,6 +21,7 @@ jobs:
         run: |
           nox -s lint
   build:
+    needs: [lint]
     runs-on: ubuntu-latest
     # Service containers to run with `runner-job`
     services:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,6 @@ jobs:
           python-version: 3.8
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip setuptools wheel
           pip install nox
       - name: Lint with flake8 in nox session
         run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -6,22 +6,7 @@ name: build
 on: [push, pull_request]
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-      - name: Install dependencies
-        run: |
-          pip install nox
-      - name: Lint with flake8 in nox session
-        run: |
-          nox -s lint
   build:
-    needs: [lint]
     runs-on: ubuntu-latest
     # Service containers to run with `runner-job`
     services:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -56,12 +56,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         pip install -e '.[TEST]'
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       env:
         # Environment variable for tests to know if running in CI environment

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -6,6 +6,21 @@ name: build
 on: [push, pull_request]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          pip install nox
+      - name: Lint with flake8 in nox session
+        run: |
+          nox -s lint
   build:
     runs-on: ubuntu-latest
     # Service containers to run with `runner-job`

--- a/noxfile.py
+++ b/noxfile.py
@@ -33,7 +33,7 @@ def lint(session):
     """Lint using flake8."""
     session.install(*lint_dependencies)
     files = ["tests", "src"] + [str(p) for p in Path(".").glob("*.py")]
-    session.run("flake8", *files)
+    session.run("flake8", *files, '--statistics', '--count')
     session.run("python", "setup.py", "check", "--metadata", "--strict")
     if "--skip_manifest_check" in session.posargs:
         pass


### PR DESCRIPTION
- Makes linting a separate workflow, instead of running it for each python version as part of the "build" workflow.
- The lint workflow now runs the nox session "lint" for python 3.8, eliminating the difference between the previously configured linting and what the nox session does.