### PR TITLE
Use contextmanager for EtlTransformations

### DIFF
--- a/src/delphyne/model/custom_vocab/base_manager/base_concept_manager.py
+++ b/src/delphyne/model/custom_vocab/base_manager/base_concept_manager.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import Set, List
 
 from ....database import Database
-from ....model.etl_stats import open_transformation
 from ....util.io import get_file_prefix
 
 logger = logging.getLogger(__name__)
@@ -30,11 +29,10 @@ class BaseConceptManager:
         if not vocab_ids:
             return
 
-        with open_transformation(name='drop_concepts') as transformation_metadata:
-            with self._db.session_scope(metadata=transformation_metadata) as session:
-                session.query(self._cdm.Concept) \
-                    .filter(self._cdm.Concept.vocabulary_id.in_(vocab_ids)) \
-                    .delete(synchronize_session=False)
+        with self._db.tracked_session_scope(name='drop_concepts') as (session, _):
+            session.query(self._cdm.Concept) \
+                .filter(self._cdm.Concept.vocabulary_id.in_(vocab_ids)) \
+                .delete(synchronize_session=False)
 
     def _load_custom_concepts(self, vocab_ids: Set[str], valid_prefixes: Set[str]) -> None:
         # Load concept_ids associated with a set of custom
@@ -50,54 +48,52 @@ class BaseConceptManager:
 
         for concept_file in self._custom_concept_files:
 
-            with open_transformation(name=f'load_{concept_file.stem}') as transformation_metadata:
+            file_prefix = get_file_prefix(concept_file, 'concept')
+            invalid_vocabs = set()
 
-                file_prefix = get_file_prefix(concept_file, 'concept')
-                invalid_vocabs = set()
+            with self._db.tracked_session_scope(name=f'load_{concept_file.stem}') \
+                    as (session, _), concept_file.open('r') as f_in:
 
-                with self._db.session_scope(metadata=transformation_metadata) as session, \
-                        concept_file.open('r') as f_in:
-                    rows = csv.DictReader(f_in, delimiter='\t')
-                    records = []
+                rows = csv.DictReader(f_in, delimiter='\t')
+                records = []
 
-                    for row in rows:
-                        concept_id = row['concept_id']
-                        vocabulary_id = row['vocabulary_id']
+                for row in rows:
+                    concept_id = row['concept_id']
+                    vocabulary_id = row['vocabulary_id']
 
-                        # quality checks
-                        if int(concept_id) < 2000000000:
-                            raise ValueError(
-                                f'{concept_file.name} must have concept_ids starting at '
-                                f'2\'000\'000\'000 (2B+ convention)')
-                        if concept_id in unique_concepts_check:
-                            raise ValueError(
-                                f'concept {concept_id} has duplicates across one or multiple '
-                                f'files')
+                    # quality checks
+                    if int(concept_id) < 2000000000:
+                        raise ValueError(
+                            f'{concept_file.name} must have concept_ids starting at '
+                            f'2\'000\'000\'000 (2B+ convention)')
+                    if concept_id in unique_concepts_check:
+                        raise ValueError(
+                            f'concept {concept_id} has duplicates across one or multiple '
+                            f'files')
 
-                        if vocabulary_id in vocab_ids:
-                            records.append(self._cdm.Concept(
-                                concept_id=row['concept_id'],
-                                concept_name=row['concept_name'],
-                                domain_id=row['domain_id'],
-                                vocabulary_id=row['vocabulary_id'],
-                                concept_class_id=row['concept_class_id'],
-                                standard_concept=row['standard_concept'],
-                                concept_code=row['concept_code'],
-                                valid_start_date=row['valid_start_date'],
-                                valid_end_date=row['valid_end_date'],
-                                invalid_reason=row['invalid_reason']
-                            ))
+                    if vocabulary_id in vocab_ids:
+                        records.append(self._cdm.Concept(
+                            concept_id=row['concept_id'],
+                            concept_name=row['concept_name'],
+                            domain_id=row['domain_id'],
+                            vocabulary_id=row['vocabulary_id'],
+                            concept_class_id=row['concept_class_id'],
+                            standard_concept=row['standard_concept'],
+                            concept_code=row['concept_code'],
+                            valid_start_date=row['valid_start_date'],
+                            valid_end_date=row['valid_end_date'],
+                            invalid_reason=row['invalid_reason']
+                        ))
 
-                        # if file prefix is valid vocab_id,
-                        # vocabulary_ids in file should match it.
-                        # comparison is case-insensitive.
-                        vocabs_lowercase = {vocab.lower() for vocab in valid_prefixes}
-                        if (file_prefix in vocabs_lowercase
-                                and vocabulary_id.lower() != file_prefix):
-                            invalid_vocabs.add(vocabulary_id)
+                    # if file prefix is valid vocab_id,
+                    # vocabulary_ids in file should match it.
+                    # comparison is case-insensitive.
+                    vocabs_lowercase = {vocab.lower() for vocab in valid_prefixes}
+                    if file_prefix in vocabs_lowercase and vocabulary_id.lower() != file_prefix:
+                        invalid_vocabs.add(vocabulary_id)
 
-                    session.add_all(records)
+                session.add_all(records)
 
-                if invalid_vocabs:
-                    logging.warning(f'{concept_file.name} contains vocabulary_ids '
-                                    f'that do not match file prefix')
+            if invalid_vocabs:
+                logging.warning(f'{concept_file.name} contains vocabulary_ids '
+                                f'that do not match file prefix')

--- a/src/delphyne/model/custom_vocab/base_manager/base_concept_manager.py
+++ b/src/delphyne/model/custom_vocab/base_manager/base_concept_manager.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Set, List
 
 from ....database import Database
-from ....model.etl_stats import EtlTransformation, etl_stats
+from ....model.etl_stats import open_transformation
 from ....util.io import get_file_prefix
 
 logger = logging.getLogger(__name__)
@@ -30,15 +30,11 @@ class BaseConceptManager:
         if not vocab_ids:
             return
 
-        transformation_metadata = EtlTransformation(name='drop_concepts')
-
-        with self._db.session_scope(metadata=transformation_metadata) as session:
-            session.query(self._cdm.Concept) \
-                .filter(self._cdm.Concept.vocabulary_id.in_(vocab_ids)) \
-                .delete(synchronize_session=False)
-
-            transformation_metadata.end_now()
-            etl_stats.add_transformation(transformation_metadata)
+        with open_transformation(name='drop_concepts') as transformation_metadata:
+            with self._db.session_scope(metadata=transformation_metadata) as session:
+                session.query(self._cdm.Concept) \
+                    .filter(self._cdm.Concept.vocabulary_id.in_(vocab_ids)) \
+                    .delete(synchronize_session=False)
 
     def _load_custom_concepts(self, vocab_ids: Set[str], valid_prefixes: Set[str]) -> None:
         # Load concept_ids associated with a set of custom
@@ -54,56 +50,54 @@ class BaseConceptManager:
 
         for concept_file in self._custom_concept_files:
 
-            transformation_metadata = EtlTransformation(name=f'load_{concept_file.stem}')
+            with open_transformation(name=f'load_{concept_file.stem}') as transformation_metadata:
 
-            file_prefix = get_file_prefix(concept_file, 'concept')
-            invalid_vocabs = set()
+                file_prefix = get_file_prefix(concept_file, 'concept')
+                invalid_vocabs = set()
 
-            with self._db.session_scope(metadata=transformation_metadata) as session, \
-                    concept_file.open('r') as f_in:
-                rows = csv.DictReader(f_in, delimiter='\t')
-                records = []
+                with self._db.session_scope(metadata=transformation_metadata) as session, \
+                        concept_file.open('r') as f_in:
+                    rows = csv.DictReader(f_in, delimiter='\t')
+                    records = []
 
-                for row in rows:
-                    concept_id = row['concept_id']
-                    vocabulary_id = row['vocabulary_id']
+                    for row in rows:
+                        concept_id = row['concept_id']
+                        vocabulary_id = row['vocabulary_id']
 
-                    # quality checks
-                    if int(concept_id) < 2000000000:
-                        raise ValueError(
-                            f'{concept_file.name} must have concept_ids starting at '
-                            f'2\'000\'000\'000 (2B+ convention)')
-                    if concept_id in unique_concepts_check:
-                        raise ValueError(
-                            f'concept {concept_id} has duplicates across one or multiple '
-                            f'files')
+                        # quality checks
+                        if int(concept_id) < 2000000000:
+                            raise ValueError(
+                                f'{concept_file.name} must have concept_ids starting at '
+                                f'2\'000\'000\'000 (2B+ convention)')
+                        if concept_id in unique_concepts_check:
+                            raise ValueError(
+                                f'concept {concept_id} has duplicates across one or multiple '
+                                f'files')
 
-                    if vocabulary_id in vocab_ids:
-                        records.append(self._cdm.Concept(
-                            concept_id=row['concept_id'],
-                            concept_name=row['concept_name'],
-                            domain_id=row['domain_id'],
-                            vocabulary_id=row['vocabulary_id'],
-                            concept_class_id=row['concept_class_id'],
-                            standard_concept=row['standard_concept'],
-                            concept_code=row['concept_code'],
-                            valid_start_date=row['valid_start_date'],
-                            valid_end_date=row['valid_end_date'],
-                            invalid_reason=row['invalid_reason']
-                        ))
+                        if vocabulary_id in vocab_ids:
+                            records.append(self._cdm.Concept(
+                                concept_id=row['concept_id'],
+                                concept_name=row['concept_name'],
+                                domain_id=row['domain_id'],
+                                vocabulary_id=row['vocabulary_id'],
+                                concept_class_id=row['concept_class_id'],
+                                standard_concept=row['standard_concept'],
+                                concept_code=row['concept_code'],
+                                valid_start_date=row['valid_start_date'],
+                                valid_end_date=row['valid_end_date'],
+                                invalid_reason=row['invalid_reason']
+                            ))
 
-                    # if file prefix is valid vocab_id,
-                    # vocabulary_ids in file should match it.
-                    # comparison is case-insensitive.
-                    vocabs_lowercase = {vocab.lower() for vocab in valid_prefixes}
-                    if file_prefix in vocabs_lowercase and vocabulary_id.lower() != file_prefix:
-                        invalid_vocabs.add(vocabulary_id)
+                        # if file prefix is valid vocab_id,
+                        # vocabulary_ids in file should match it.
+                        # comparison is case-insensitive.
+                        vocabs_lowercase = {vocab.lower() for vocab in valid_prefixes}
+                        if (file_prefix in vocabs_lowercase
+                                and vocabulary_id.lower() != file_prefix):
+                            invalid_vocabs.add(vocabulary_id)
 
-                session.add_all(records)
+                    session.add_all(records)
 
-                transformation_metadata.end_now()
-                etl_stats.add_transformation(transformation_metadata)
-
-            if invalid_vocabs:
-                logging.warning(f'{concept_file.name} contains vocabulary_ids '
-                                f'that do not match file prefix')
+                if invalid_vocabs:
+                    logging.warning(f'{concept_file.name} contains vocabulary_ids '
+                                    f'that do not match file prefix')

--- a/src/delphyne/model/custom_vocab/base_manager/base_vocab_manager.py
+++ b/src/delphyne/model/custom_vocab/base_manager/base_vocab_manager.py
@@ -142,7 +142,7 @@ class BaseVocabManager:
         if not vocabs_to_drop:
             return
 
-        with self._db.tracked_session_scope(name='drop_concepts') as (session, _):
+        with self._db.tracked_session_scope(name='drop_vocabs') as (session, _):
             session.query(self._cdm.Vocabulary) \
                 .filter(self._cdm.Vocabulary.vocabulary_id.in_(vocabs_to_drop)) \
                 .delete(synchronize_session=False)

--- a/src/delphyne/model/custom_vocab/base_manager/base_vocab_manager.py
+++ b/src/delphyne/model/custom_vocab/base_manager/base_vocab_manager.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import List, Dict
 
 from ....database import Database
-from ....model.etl_stats import EtlTransformation, etl_stats
+from ....model.etl_stats import open_transformation
 from ....util.io import get_file_prefix
 
 logger = logging.getLogger(__name__)
@@ -143,15 +143,11 @@ class BaseVocabManager:
         if not vocabs_to_drop:
             return
 
-        transformation_metadata = EtlTransformation(name='drop_concepts')
-
-        with self._db.session_scope(metadata=transformation_metadata) as session:
-            session.query(self._cdm.Vocabulary) \
-                .filter(self._cdm.Vocabulary.vocabulary_id.in_(vocabs_to_drop)) \
-                .delete(synchronize_session=False)
-
-            transformation_metadata.end_now()
-            etl_stats.add_transformation(transformation_metadata)
+        with open_transformation(name='drop_concepts') as transformation_metadata:
+            with self._db.session_scope(metadata=transformation_metadata) as session:
+                session.query(self._cdm.Vocabulary) \
+                    .filter(self._cdm.Vocabulary.vocabulary_id.in_(vocabs_to_drop)) \
+                    .delete(synchronize_session=False)
 
     def _load_custom_vocabs(self) -> None:
         # Load new and updated custom vocabularies to the database
@@ -171,42 +167,40 @@ class BaseVocabManager:
             file_prefix = get_file_prefix(vocab_file, 'vocabulary')
             invalid_vocabs = set()
 
-            transformation_metadata = EtlTransformation(name=f'load_{vocab_file.stem}')
+            with open_transformation(name=f'load_{vocab_file.stem}') as transformation_metadata:
 
-            with self._db.session_scope(metadata=transformation_metadata) as session, \
-                    vocab_file.open('r') as f_in:
-                rows = csv.DictReader(f_in, delimiter='\t')
-                records = []
+                with self._db.session_scope(metadata=transformation_metadata) as session, \
+                        vocab_file.open('r') as f_in:
+                    rows = csv.DictReader(f_in, delimiter='\t')
+                    records = []
 
-                for row in rows:
-                    vocabulary_id = row['vocabulary_id']
+                    for row in rows:
+                        vocabulary_id = row['vocabulary_id']
 
-                    if vocabulary_id in vocabs_to_create:
-                        records.append(self._cdm.Vocabulary(
-                            vocabulary_id=row['vocabulary_id'],
-                            vocabulary_name=row['vocabulary_name'],
-                            vocabulary_reference=row['vocabulary_reference'],
-                            vocabulary_version=row['vocabulary_version'],
-                            vocabulary_concept_id=row['vocabulary_concept_id']
-                        ))
-                    else:
-                        ignored_vocabs.update([vocabulary_id])
+                        if vocabulary_id in vocabs_to_create:
+                            records.append(self._cdm.Vocabulary(
+                                vocabulary_id=row['vocabulary_id'],
+                                vocabulary_name=row['vocabulary_name'],
+                                vocabulary_reference=row['vocabulary_reference'],
+                                vocabulary_version=row['vocabulary_version'],
+                                vocabulary_concept_id=row['vocabulary_concept_id']
+                            ))
+                        else:
+                            ignored_vocabs.update([vocabulary_id])
 
-                    # if file prefix is valid vocab_id,
-                    # vocabulary_ids in file should match it.
-                    # comparison is case-insensitive.
-                    vocabs_lowercase = {vocab.lower() for vocab in self.vocabs_from_disk}
-                    if file_prefix in vocabs_lowercase and vocabulary_id.lower() != file_prefix:
-                        invalid_vocabs.add(vocabulary_id)
+                        # if file prefix is valid vocab_id,
+                        # vocabulary_ids in file should match it.
+                        # comparison is case-insensitive.
+                        vocabs_lowercase = {vocab.lower() for vocab in self.vocabs_from_disk}
+                        if (file_prefix in vocabs_lowercase
+                                and vocabulary_id.lower() != file_prefix):
+                            invalid_vocabs.add(vocabulary_id)
 
-                session.add_all(records)
+                    session.add_all(records)
 
-                transformation_metadata.end_now()
-                etl_stats.add_transformation(transformation_metadata)
-
-            if invalid_vocabs:
-                logging.warning(f'{vocab_file.name} contains vocabulary_ids '
-                                f'that do not match file prefix')
+                if invalid_vocabs:
+                    logging.warning(f'{vocab_file.name} contains vocabulary_ids '
+                                    f'that do not match file prefix')
 
         if ignored_vocabs:
             logger.info(f'Skipped records with vocabulary_id values that '

--- a/src/delphyne/model/etl_stats/__init__.py
+++ b/src/delphyne/model/etl_stats/__init__.py
@@ -1,2 +1,2 @@
-from .etl_stats import EtlSource, EtlTransformation, EtlStats, etl_stats
+from .etl_stats import EtlSource, EtlTransformation, EtlStats, etl_stats, open_transformation
 from .etl_stats_reporter import EtlStatsReporter

--- a/src/delphyne/model/orm_wrapper.py
+++ b/src/delphyne/model/orm_wrapper.py
@@ -22,7 +22,7 @@ from typing import Callable, List
 
 from sqlalchemy.orm.session import Session
 
-from .etl_stats import EtlTransformation, etl_stats
+from .etl_stats import EtlTransformation, open_transformation
 from ..database import Database, events
 
 logger = logging.getLogger(__name__)
@@ -61,22 +61,24 @@ class OrmWrapper(ABC):
             persisting the ORM objects
         """
         logger.info(f'Executing transformation: {statement.__name__}')
-        transformation_metadata = EtlTransformation(name=statement.__name__)
+        with open_transformation(name=statement.__name__) as transformation_metadata:
+            with self.db.session_scope(raise_on_error=False,
+                                       metadata=transformation_metadata) as session:
+                func_args = signature(statement).parameters
+                if 'session' in func_args:
+                    records_to_insert = statement(self, session)
+                else:
+                    records_to_insert = statement(self)
+                logger.info(f'Saving {len(records_to_insert)} objects')
+                if bulk:
+                    session.bulk_save_objects(records_to_insert)
+                    self._collect_query_statistics_bulk_mode(session, records_to_insert,
+                                                             transformation_metadata)
+                else:
+                    session.add_all(records_to_insert)
 
-        with self.db.session_scope(raise_on_error=False,
-                                   metadata=transformation_metadata) as session:
-            func_args = signature(statement).parameters
-            records_to_insert = statement(self, session) if 'session' in func_args else statement(self)
-            logger.info(f'Saving {len(records_to_insert)} objects')
-            if bulk:
-                session.bulk_save_objects(records_to_insert)
-                self._collect_query_statistics_bulk_mode(session, records_to_insert, transformation_metadata)
-            else:
-                session.add_all(records_to_insert)
-
-        transformation_metadata.end_now()
-        logger.info(f'{statement.__name__} completed with success status: {transformation_metadata.query_success}')
-        etl_stats.add_transformation(transformation_metadata)
+            logger.info(f'{statement.__name__} completed with success status: '
+                        f'{transformation_metadata.query_success}')
 
     @staticmethod
     def _collect_query_statistics_bulk_mode(session: Session,

--- a/src/delphyne/model/stcm/stcm_loader.py
+++ b/src/delphyne/model/stcm/stcm_loader.py
@@ -8,7 +8,6 @@ from typing import Dict, Set
 from sqlalchemy import MetaData
 from sqlalchemy.exc import InvalidRequestError
 
-from ..etl_stats import open_transformation
 from ..._paths import STCM_DIR, STCM_VERSION_FILE
 from ...cdm._schema_placeholders import VOCAB_SCHEMA
 from ...cdm.vocabularies import BaseSourceToConceptMapVersion
@@ -133,36 +132,35 @@ class StcmLoader:
 
     def _load_stcm_from_file(self, stcm_file: Path) -> None:
         logger.info(f'Loading STCM file: {stcm_file.name}')
-        with open_transformation(name=f'load_{stcm_file.stem}') as transformation_metadata:
-            with self._db.session_scope(metadata=transformation_metadata) as session, \
-                    stcm_file.open('r') as f_in:
-                rows = csv.DictReader(f_in)
-                ignored_vocabs = Counter()
-                unrecognized_vocabs = Counter()
+        with self._db.tracked_session_scope(name=f'load_{stcm_file.stem}') as (session, _), \
+                stcm_file.open('r') as f_in:
+            rows = csv.DictReader(f_in)
+            ignored_vocabs = Counter()
+            unrecognized_vocabs = Counter()
 
-                for i, row in enumerate(rows, start=2):
-                    source_vocabulary_id = row['source_vocabulary_id']
-                    if source_vocabulary_id not in self._provided_stcm_versions:
-                        unrecognized_vocabs.update([source_vocabulary_id])
-                        continue
-                    if source_vocabulary_id not in self._stcm_vocabs_to_update:
-                        ignored_vocabs.update([source_vocabulary_id])
-                        continue
-                    # Skip unmapped records
-                    target_concept_id = int(row['target_concept_id'])
-                    if target_concept_id == 0:
-                        continue
-                    if source_vocabulary_id not in self._loaded_vocabulary_ids:
-                        raise ValueError(f'Cannot insert line {i} of {stcm_file.name}. '
-                                         f'{source_vocabulary_id} is not in the vocabulary table')
-                    session.add(self._cdm.SourceToConceptMap(**row))
+            for i, row in enumerate(rows, start=2):
+                source_vocabulary_id = row['source_vocabulary_id']
+                if source_vocabulary_id not in self._provided_stcm_versions:
+                    unrecognized_vocabs.update([source_vocabulary_id])
+                    continue
+                if source_vocabulary_id not in self._stcm_vocabs_to_update:
+                    ignored_vocabs.update([source_vocabulary_id])
+                    continue
+                # Skip unmapped records
+                target_concept_id = int(row['target_concept_id'])
+                if target_concept_id == 0:
+                    continue
+                if source_vocabulary_id not in self._loaded_vocabulary_ids:
+                    raise ValueError(f'Cannot insert line {i} of {stcm_file.name}. '
+                                     f'{source_vocabulary_id} is not in the vocabulary table')
+                session.add(self._cdm.SourceToConceptMap(**row))
 
-                if unrecognized_vocabs:
-                    logger.warning(f'Skipped records with source_vocabulary_id values that '
-                                   f'were not present in {STCM_VERSION_FILE.name}: '
-                                   f'{unrecognized_vocabs.most_common()}')
+            if unrecognized_vocabs:
+                logger.warning(f'Skipped records with source_vocabulary_id values that '
+                               f'were not present in {STCM_VERSION_FILE.name}: '
+                               f'{unrecognized_vocabs.most_common()}')
 
-                if ignored_vocabs:
-                    logger.info(f'Skipped records with source_vocabulary_id values that '
-                                f'were already loaded under the current version: '
-                                f'{ignored_vocabs.most_common()}')
+            if ignored_vocabs:
+                logger.info(f'Skipped records with source_vocabulary_id values that '
+                            f'were already loaded under the current version: '
+                            f'{ignored_vocabs.most_common()}')


### PR DESCRIPTION
- Simplifies tracking changes via `EtlTransformation` by using a contextmanager. That way there is no need to manually set start or end times and instances are automatically added to the `etl_stats` collection.
- Add a `tracked_session_scope` method to `Database` using the previous as part of a session. That way both the session and the `EtlTransformation` instances can be managed in a single with statement.