### PR TITLE
Rename cost column in v5.3.1 CDM

### DIFF
--- a/src/delphyne/cdm/cdm531/health_economics.py
+++ b/src/delphyne/cdm/cdm531/health_economics.py
@@ -164,7 +164,7 @@ class BaseCostCdm531:
         return Column(Integer)
 
     @declared_attr
-    def reveue_code_source_value(cls):
+    def revenue_code_source_value(cls):
         return Column(String(50))
 
     @declared_attr


### PR DESCRIPTION
Closes #108 

I realized we'll need this sooner than later when performing mappings between versions..

That's it, right?