### PR TITLE
Constraint errors option

### DIFF
--- a/src/delphyne/database/constraints/constraint_manager.py
+++ b/src/delphyne/database/constraints/constraint_manager.py
@@ -428,7 +428,7 @@ class ConstraintManager:
             self._add_constraint_in_db(constraint, errors)
 
     @_invalidate_db_cache
-    def drop_constraint(self, name: str, errors: str = 'raise') -> None:
+    def drop_constraint_or_index(self, name: str, errors: str = 'raise') -> None:
         """
         Drop a single constraint/index by name.
 
@@ -457,7 +457,7 @@ class ConstraintManager:
             self._drop_constraint_in_db(constraint, errors)
 
     @_invalidate_db_cache
-    def add_constraint(self, name: str, errors: str = 'raise') -> None:
+    def add_constraint_or_index(self, name: str, errors: str = 'raise') -> None:
         """
         Add a single constraint/index by name.
 

--- a/tests/python/database/constraints/test_constraints.py
+++ b/tests/python/database/constraints/test_constraints.py
@@ -56,13 +56,13 @@ def test_drop_and_add_single_index(cdm531_wrapper_with_tables_created: Wrapper):
     assert get_index_names(meas_table.indexes) == expected_full
 
     # Calling drop_constraint will remove the index on person_id
-    wrapper.db.constraint_manager.drop_constraint(person_id_index)
+    wrapper.db.constraint_manager.drop_constraint_or_index(person_id_index)
     meas_table = reflect_table(wrapper, full_table_name)
     expected = expected_sets.measurement_indexes_without_person_index
     assert get_index_names(meas_table.indexes) == expected
 
     # Calling add_index will restore the index on person_id
-    wrapper.db.constraint_manager.add_constraint(person_id_index)
+    wrapper.db.constraint_manager.add_constraint_or_index(person_id_index)
     meas_table = reflect_table(wrapper, full_table_name)
     assert get_index_names(meas_table.indexes) == expected_full
 
@@ -76,12 +76,12 @@ def test_drop_and_add_pk(cdm600_wrapper_with_tables_created: Wrapper):
     sc_table = reflect_table(wrapper, full_table_name)
     assert sc_table.primary_key.name == 'pk_survey_conduct'
 
-    wrapper.db.constraint_manager.drop_constraint(survey_conduct_pk)
+    wrapper.db.constraint_manager.drop_constraint_or_index(survey_conduct_pk)
     sc_table = reflect_table(wrapper, full_table_name)
     # SQLAlchemy leaves an empty PrimaryKeyConstraint object
     assert sc_table.primary_key.name is None
 
-    wrapper.db.constraint_manager.add_constraint(survey_conduct_pk)
+    wrapper.db.constraint_manager.add_constraint_or_index(survey_conduct_pk)
     sc_table = reflect_table(wrapper, full_table_name)
     assert sc_table.primary_key.name == 'pk_survey_conduct'
 
@@ -98,26 +98,26 @@ def test_exceptions(cdm600_wrapper_with_tables_created: Wrapper):
 
     # Cannot add index that doesn't exist
     with pytest.raises(KeyError):
-        wrapper.db.constraint_manager.add_constraint('but_now_alone_i_lie')
+        wrapper.db.constraint_manager.add_constraint_or_index('but_now_alone_i_lie')
     # Cannot drop index that never existed
     with pytest.raises(KeyError):
-        wrapper.db.constraint_manager.drop_constraint('and_weep_beside_the_tree')
+        wrapper.db.constraint_manager.drop_constraint_or_index('and_weep_beside_the_tree')
 
     # This index can be dropped
-    wrapper.db.constraint_manager.drop_constraint('ix_measurement_person_id')
+    wrapper.db.constraint_manager.drop_constraint_or_index('ix_measurement_person_id')
     # But not again once already dropped
     with pytest.raises(KeyError):
-        wrapper.db.constraint_manager.drop_constraint('ix_measurement_person_id')
+        wrapper.db.constraint_manager.drop_constraint_or_index('ix_measurement_person_id')
 
     # Invalid errors value is not accepted
     with pytest.raises(AssertionError):
-        wrapper.db.constraint_manager.drop_constraint('pk_person', errors='divine_intervention')
+        wrapper.db.constraint_manager.drop_constraint_or_index('pk_person', errors='cry')
 
     # If a valid constraint cannot be added/dropped, raise an exception,
     # unless specified otherwise.
     with pytest.raises(InternalError):
-        wrapper.db.constraint_manager.drop_constraint('pk_person')
-    wrapper.db.constraint_manager.drop_constraint('pk_person', errors='ignore')
+        wrapper.db.constraint_manager.drop_constraint_or_index('pk_person')
+    wrapper.db.constraint_manager.drop_constraint_or_index('pk_person', errors='ignore')
 
     wrapper.db.constraint_manager.drop_cdm_constraints()
     with pytest.raises(ProgrammingError):
@@ -142,7 +142,7 @@ def test_diff_index_name_is_recognized(cdm600_wrapper_with_tables_created: Wrapp
 
     # Trying to add the original index will have no effect
     with caplog.at_level(logging.INFO):
-        wrapper.db.constraint_manager.add_constraint('ix_specimen_person_id')
+        wrapper.db.constraint_manager.add_constraint_or_index('ix_specimen_person_id')
     specimen_table = reflect_table(wrapper, full_table_name)
     indexes = get_index_names(specimen_table.indexes)
     assert indexes == {'ix_specimen_specimen_concept_id', 'indexus_anderus'}


### PR DESCRIPTION
- Resolves #131 by adding an `errors`option to the constraint calls, which allow you to specify what should happen in case a constraint/index cannot be added/dropped.
- No longer separate methods for adding/dropping a single index or constraint. Only `drop_constraint` and `add_constraint`.