### PR TITLE
Fix fixtures

### DIFF
--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -113,40 +113,35 @@ def test_db_uri(default_main_config: MainConfig) -> str:
     return f'postgresql://{username}:{password}@{hostname}:{port}/{database}'
 
 
-@pytest.mark.usefixtures("container")
 @pytest.fixture(scope='function')
-def test_db(test_db_uri: str) -> None:
+def test_db(container, test_db_uri: str) -> None:
     engine = create_engine(test_db_uri)
     create_database(engine.url)
     yield
     drop_database(engine.url)
 
 
-@pytest.mark.usefixtures("test_db")
 @pytest.fixture(scope='function')
-def wrapper_cdm531(default_main_config: MainConfig) -> Wrapper:
+def wrapper_cdm531(test_db, default_main_config: MainConfig) -> Wrapper:
     wrapper = Wrapper(default_main_config, cdm531)
     return wrapper
 
 
-@pytest.mark.usefixtures("test_db")
 @pytest.fixture(scope='function')
-def wrapper_cdm600(default_main_config: MainConfig) -> Wrapper:
+def wrapper_cdm600(test_db, default_main_config: MainConfig) -> Wrapper:
     wrapper = Wrapper(default_main_config, cdm600)
     return wrapper
 
 
-@pytest.mark.usefixtures("test_db")
 @pytest.fixture(scope='function')
-def cdm531_wrapper_with_tables_created(wrapper_cdm531: Wrapper) -> Wrapper:
+def cdm531_wrapper_with_tables_created(test_db, wrapper_cdm531: Wrapper) -> Wrapper:
     wrapper_cdm531.create_schemas()
     wrapper_cdm531.create_cdm()
     return wrapper_cdm531
 
 
-@pytest.mark.usefixtures("test_db")
 @pytest.fixture(scope='function')
-def cdm600_wrapper_with_tables_created(wrapper_cdm600: Wrapper) -> Wrapper:
+def cdm600_wrapper_with_tables_created(test_db, wrapper_cdm600: Wrapper) -> Wrapper:
     wrapper_cdm600.create_schemas()
     wrapper_cdm600.create_cdm()
     return wrapper_cdm600

--- a/tests/python/database/constraints/test_constraints.py
+++ b/tests/python/database/constraints/test_constraints.py
@@ -44,7 +44,6 @@ def get_all_db_table_object_names(metadata: MetaData) -> Set[str]:
     return all_db_objects
 
 
-@pytest.mark.usefixtures("container", "test_db")
 def test_drop_and_add_single_index(cdm531_wrapper_with_tables_created: Wrapper):
     person_id_index = 'ix_measurement_person_id'
     full_table_name = 'cdm.measurement'
@@ -67,7 +66,6 @@ def test_drop_and_add_single_index(cdm531_wrapper_with_tables_created: Wrapper):
     assert get_index_names(meas_table.indexes) == expected_full
 
 
-@pytest.mark.usefixtures("container", "test_db")
 def test_drop_and_add_pk(cdm600_wrapper_with_tables_created: Wrapper):
     survey_conduct_pk = 'pk_survey_conduct'
     full_table_name = 'cdm.survey_conduct'
@@ -86,7 +84,6 @@ def test_drop_and_add_pk(cdm600_wrapper_with_tables_created: Wrapper):
     assert sc_table.primary_key.name == 'pk_survey_conduct'
 
 
-@pytest.mark.usefixtures("container", "test_db")
 def test_exceptions(cdm600_wrapper_with_tables_created: Wrapper):
     wrapper = cdm600_wrapper_with_tables_created
 
@@ -125,7 +122,6 @@ def test_exceptions(cdm600_wrapper_with_tables_created: Wrapper):
     wrapper.db.constraint_manager.add_table_constraints('observation', errors='ignore')
 
 
-@pytest.mark.usefixtures("container", "test_db")
 def test_diff_index_name_is_recognized(cdm600_wrapper_with_tables_created: Wrapper, caplog):
     wrapper = cdm600_wrapper_with_tables_created
     full_table_name = 'cdm.specimen'
@@ -149,7 +145,6 @@ def test_diff_index_name_is_recognized(cdm600_wrapper_with_tables_created: Wrapp
     assert 'equivalent already exists with name "indexus_anderus"' in caplog.text
 
 
-@pytest.mark.usefixtures("container", "test_db")
 def test_drop_and_add_table_constraints(cdm600_wrapper_with_tables_created: Wrapper):
     full_table_name = 'cdm.specimen'
     wrapper = cdm600_wrapper_with_tables_created
@@ -172,7 +167,6 @@ def test_drop_and_add_table_constraints(cdm600_wrapper_with_tables_created: Wrap
     assert all_names == expected_sets.all_specimen_objects
 
 
-@pytest.mark.usefixtures("container", "test_db")
 def test_drop_and_add_cdm_constraints(cdm600_wrapper_with_tables_created: Wrapper):
     wrapper = cdm600_wrapper_with_tables_created
 
@@ -192,7 +186,6 @@ def test_drop_and_add_cdm_constraints(cdm600_wrapper_with_tables_created: Wrappe
     assert all_db_objects == expected_sets.db_table_objects_full
 
 
-@pytest.mark.usefixtures("container", "test_db")
 def test_drop_and_add_all_constraints(cdm600_wrapper_with_tables_created: Wrapper):
     wrapper = cdm600_wrapper_with_tables_created
 

--- a/tests/python/model/mapping/test_code_mapper.py
+++ b/tests/python/model/mapping/test_code_mapper.py
@@ -11,7 +11,6 @@ pytestmark = pytest.mark.skipif(condition=docker_not_available(),
                                 reason='Docker daemon is not running')
 
 
-@pytest.mark.usefixtures("test_db")
 @pytest.fixture(scope='function')
 def cdm600_wrapper_with_loaded_relationships(cdm600_wrapper_with_tables_created: Wrapper) \
         -> Wrapper:
@@ -62,7 +61,6 @@ def test_codemapping_instantiation():
     assert not_found_instance.target_vocabulary_id is None
 
 
-@pytest.mark.usefixtures("container", "test_db")
 def test_restrict_to_codes_option(cdm600_wrapper_with_loaded_relationships: Wrapper):
 
     wrapper = cdm600_wrapper_with_loaded_relationships
@@ -73,7 +71,6 @@ def test_restrict_to_codes_option(cdm600_wrapper_with_loaded_relationships: Wrap
     assert all(code in map_dict.mapping_dict.keys() for code in ['SOURCE_1', 'SOURCE_2'])
 
 
-@pytest.mark.usefixtures("container", "test_db")
 def test_multiple_source_vocabularies(cdm600_wrapper_with_loaded_relationships: Wrapper):
 
     wrapper = cdm600_wrapper_with_loaded_relationships
@@ -83,7 +80,6 @@ def test_multiple_source_vocabularies(cdm600_wrapper_with_loaded_relationships: 
     assert all(code in map_dict.mapping_dict.keys() for code in ['SOURCE_1', 'TARGET_1'])
 
 
-@pytest.mark.usefixtures("container", "test_db")
 def test_empty_dictionary_warnings(cdm600_wrapper_with_loaded_relationships: Wrapper, caplog):
 
     wrapper = cdm600_wrapper_with_loaded_relationships
@@ -99,7 +95,6 @@ def test_empty_dictionary_warnings(cdm600_wrapper_with_loaded_relationships: Wra
     assert "Trying to retrieve mappings from an empty dictionary!" in caplog.text
 
 
-@pytest.mark.usefixtures("container", "test_db")
 def test_other_dictionary_warnings(cdm600_wrapper_with_loaded_relationships: Wrapper, caplog):
 
     wrapper = cdm600_wrapper_with_loaded_relationships
@@ -116,7 +111,6 @@ def test_other_dictionary_warnings(cdm600_wrapper_with_loaded_relationships: Wra
            " {'SOURCE_1'}" in caplog.text
 
 
-@pytest.mark.usefixtures("container", "test_db")
 def test_unknown_source_code(mapping_dictionary: MappingDict, caplog):
 
     map_dict = mapping_dictionary
@@ -137,7 +131,6 @@ def test_unknown_source_code(mapping_dictionary: MappingDict, caplog):
     assert result_no_code_concept_only == [0]
 
 
-@pytest.mark.usefixtures("container", "test_db")
 def test_code_with_no_match(mapping_dictionary: MappingDict, caplog):
 
     map_dict = mapping_dictionary
@@ -165,7 +158,6 @@ def test_code_with_no_match(mapping_dictionary: MappingDict, caplog):
     assert result_no_match_concept_only == [0]
 
 
-@pytest.mark.usefixtures("container", "test_db")
 def test_code_with_one_match(mapping_dictionary: MappingDict):
 
     map_dict = mapping_dictionary
@@ -191,7 +183,6 @@ def test_code_with_one_match(mapping_dictionary: MappingDict):
     assert result_1_match_concept_only == [4]
 
 
-@pytest.mark.usefixtures("container", "test_db")
 def test_code_with_multiple_matches(mapping_dictionary: MappingDict):
 
     map_dict = mapping_dictionary
@@ -230,7 +221,6 @@ def test_code_with_multiple_matches(mapping_dictionary: MappingDict):
     assert result_multi_match_concept_only == [4, 5]
 
 
-@pytest.mark.usefixtures("container", "test_db")
 def test_code_with_multiple_matches_only_first(mapping_dictionary: MappingDict, caplog):
 
     map_dict = mapping_dictionary
@@ -258,7 +248,6 @@ def test_code_with_multiple_matches_only_first(mapping_dictionary: MappingDict, 
     assert result_multi_match_concept_only == 4
 
 
-@pytest.mark.usefixtures("container", "test_db")
 def test_code_mapping_to_invalid_standard_concepts(mapping_dictionary: MappingDict):
 
     map_dict = mapping_dictionary
@@ -282,7 +271,6 @@ def test_code_mapping_to_invalid_standard_concepts(mapping_dictionary: MappingDi
         assert getattr(result_no_match[0], attr) == value
 
 
-@pytest.mark.usefixtures("container", "test_db")
 def test_code_mapping_to_non_standard_concept(mapping_dictionary: MappingDict):
 
     map_dict = mapping_dictionary
@@ -306,7 +294,6 @@ def test_code_mapping_to_non_standard_concept(mapping_dictionary: MappingDict):
         assert getattr(result_no_match[0], attr) == value
 
 
-@pytest.mark.usefixtures("container", "test_db")
 def test_source_code_filters(cdm600_wrapper_with_loaded_relationships: Wrapper):
 
     wrapper = cdm600_wrapper_with_loaded_relationships
@@ -326,7 +313,6 @@ def test_source_code_filters(cdm600_wrapper_with_loaded_relationships: Wrapper):
     assert map_dict_invalid_only.mapping_dict.keys() == {'SOURCE_7'}
 
 
-@pytest.mark.usefixtures("container", "test_db")
 def test_valid_code_with_invalid_relationships(mapping_dictionary: MappingDict):
 
     map_dict = mapping_dictionary

--- a/tests/python/model/standard_vocab/test_standard_vocab.py
+++ b/tests/python/model/standard_vocab/test_standard_vocab.py
@@ -37,7 +37,6 @@ def insert_dummy_domain_record(wrapper: Wrapper):
         session.add(domain_record)
 
 
-@pytest.mark.usefixtures("container", "test_db")
 def test_standard_vocab_exceptions(cdm600_wrapper_with_tables_created: Wrapper,
                                    base_standard_vocab_dir: Path,
                                    ):
@@ -71,7 +70,6 @@ def test_standard_vocab_exceptions(cdm600_wrapper_with_tables_created: Wrapper,
             wrapper.vocab_manager.standard_vocabularies.load()
 
 
-@pytest.mark.usefixtures("container", "test_db")
 def test_standard_vocab_loading(cdm600_wrapper_with_tables_created: Wrapper,
                                 base_standard_vocab_dir: Path,
                                 ):

--- a/tests/python/model/stcm/test_stcm_loader.py
+++ b/tests/python/model/stcm/test_stcm_loader.py
@@ -32,7 +32,6 @@ def base_stcm_dir(test_data_dir: Path) -> Path:
     return test_data_dir / 'stcm'
 
 
-@pytest.mark.usefixtures("test_db")
 @pytest.fixture(scope='function')
 def cdm600_wrapper_no_constraints(cdm600_wrapper_with_tables_created: Wrapper) -> Wrapper:
     """cdm600 wrapper with tables created, but without constraints."""
@@ -51,7 +50,6 @@ def mock_stcm_paths(base_dir: Path, stcm_dir_name: str):
         yield
 
 
-@pytest.mark.usefixtures("container", "test_db")
 def test_stcm_exceptions(cdm600_wrapper_no_constraints: Wrapper, base_stcm_dir: Path, caplog):
     wrapper = cdm600_wrapper_no_constraints
 
@@ -82,7 +80,6 @@ def test_stcm_exceptions(cdm600_wrapper_no_constraints: Wrapper, base_stcm_dir: 
         assert 'Table vocab.source_to_concept_map_version does not exist' in caplog.text
 
 
-@pytest.mark.usefixtures("container", "test_db")
 def test_load_stcm(cdm600_wrapper_no_constraints: Wrapper, base_stcm_dir: Path, caplog):
     wrapper = cdm600_wrapper_no_constraints
     load_minimal_vocabulary(wrapper=wrapper)
@@ -109,7 +106,6 @@ def test_load_stcm(cdm600_wrapper_no_constraints: Wrapper, base_stcm_dir: Path, 
     assert "No new STCM versions provided" in caplog.text
 
 
-@pytest.mark.usefixtures("container", "test_db")
 def test_stcm_delete(cdm600_wrapper_no_constraints: Wrapper, base_stcm_dir: Path):
     wrapper = cdm600_wrapper_no_constraints
 

--- a/tests/python/wrapper/test_wrapper.py
+++ b/tests/python/wrapper/test_wrapper.py
@@ -29,7 +29,6 @@ def test_db_exists():
     assert Database.can_connect(uri)
 
 
-@pytest.mark.usefixtures("test_db")
 def test_create_schemas(wrapper_cdm531: Wrapper):
     schemas = inspect(wrapper_cdm531.db.engine).get_schema_names()
     assert set(schemas) == {'information_schema', 'public'}
@@ -38,7 +37,6 @@ def test_create_schemas(wrapper_cdm531: Wrapper):
     assert set(schemas) == {'information_schema', 'public', 'cdm', 'vocab'}
 
 
-@pytest.mark.usefixtures("test_db")
 def test_create_tables_cdm531(wrapper_cdm531: Wrapper):
     wrapper_cdm531.create_schemas()
     wrapper_cdm531.create_cdm()
@@ -57,7 +55,6 @@ def test_create_tables_cdm531(wrapper_cdm531: Wrapper):
         'dose_era'}
 
 
-@pytest.mark.usefixtures("test_db")
 def test_create_tables_cdm600(wrapper_cdm600: Wrapper):
     wrapper_cdm600.create_schemas()
     wrapper_cdm600.create_cdm()

--- a/tests/python/wrapper/test_wrapper.py
+++ b/tests/python/wrapper/test_wrapper.py
@@ -23,10 +23,9 @@ def test_connection_invalid(caplog):
     assert 'Database "postgres" does not exist' not in caplog.text
 
 
-@pytest.mark.usefixtures("test_db")
-def test_db_exists():
-    uri = 'postgresql://postgres:secret@localhost:7722/test_db'
-    assert Database.can_connect(uri)
+@pytest.mark.usefixtures("test_db_module")
+def test_db_exists(test_db_module_scope_uri):
+    assert Database.can_connect(test_db_module_scope_uri)
 
 
 def test_create_schemas(wrapper_cdm531: Wrapper):

--- a/tests/test_data/run_configs/module_scope_db_config.yml
+++ b/tests/test_data/run_configs/module_scope_db_config.yml
@@ -1,0 +1,19 @@
+database:
+  host: 'localhost'
+  port: 7722
+  database_name: 'test_db_module'
+  username: 'postgres'
+  password: 'secret'
+
+schema_translate_map:
+  cdm_schema: 'cdm'
+  vocabulary_schema: 'vocab'
+
+run_options:
+  skip_vocabulary_loading: False
+  skip_custom_vocabulary_loading: True
+  skip_source_to_concept_map_loading: False
+  write_reports: False
+
+sql_parameters:
+#placeholder: 'value'


### PR DESCRIPTION
Resolves #154 

- Fixes the incorrectly configured fixture dependencies (`@pytest.mark.usefixtures` cannot be used on fixtures but only on tests)
- Make some fixtures available on multiple scopes to allow for more performant test runs when the tests don't require a fresh database for each test

I have the feeling the overall fixture organization could be improved a bit, but it's probably a better idea to revise that as part of #149 