### PR TITLE
Document STCM Loader

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,6 +13,7 @@ copyright = f"2021, {author}"
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
+    "sphinx.ext.autosectionlabel",
     # "numpydoc",
 ]
 

--- a/docs/custom_vocab.rst
+++ b/docs/custom_vocab.rst
@@ -9,17 +9,20 @@ Custom Vocabulary files
 -----------------------
 
 Non-standard vocabulary data can be provided as tab-delimited (tsv) files.
-The file names must end with the name of the vocabulary table they should be inserted in (e.g. concept.tsv).
-Currently, target tables concept, concept_class and vocabulary are supported.
+The file names must end with the name of the vocabulary table they should be inserted in
+(e.g. concept.tsv). File name matching is case-insensitive.
+Currently, target tables CONCEPT, CONCEPT_CLASS, and VOCABULARY are supported.
 
-The custom vocabulary files may contain data of one or more custom vocabularies.
-When a vocabulary file contains data of only one custom vocabulary,
+The custom vocabulary files may contain data from one or more custom vocabularies.
+When a vocabulary file contains data from only one custom vocabulary,
 it's good practice to prepend the vocabulary_id to the file name (e.g. MYVOCAB_concept.tsv).
 This way, if the vocabulary version hasn't changed (see `Versioning`_),
 the file will be ignored without needing to parse the file contents.
 
-For custom vocabularies, the vocabulary_concept_id (vocabulary) and
-concept_class_concept_id (concept_class) should always be set to 0.
+For custom vocabularies, the ``vocabulary_concept_id`` (VOCABULARY) and
+``concept_class_concept_id`` (CONCEPT_CLASS) should always be set to ``0``.
+Additionally, CONCEPT records should always have a ``concept_id`` **above 2 billion**
+(e.g. starting at ``2000000001``) to prevent conflicts with concept_ids from the official OMOP vocabularies.
 
 Files have to be placed in te following folder:
 
@@ -29,15 +32,16 @@ Files have to be placed in te following folder:
     └── resources
         └── vocabularies
             └── custom
-                ├── MYVOCAB_vocabulary.tsv
                 ├── MYVOCAB_concept.tsv
-                ├── vocabulary.tsv
+                ├── MYVOCAB_concept_class.tsv
+                ├── MYVOCAB_vocabulary.tsv
+                ├── mixed_vocabulary.tsv
                 └── etc.
 
 Add to pipeline
 ---------------
 
-Make sure the `skip_custom_vocabulary_loading` option in your config.yml is set to False.
+Make sure the ``skip_custom_vocabulary_loading`` option in your config.yml is set to False.
 
 If you're also using STCM files, the recommended way to load
 the files is with the following call as part of your Wrapper's run method:
@@ -47,17 +51,15 @@ the files is with the following call as part of your Wrapper's run method:
    self.vocab_manager.load_custom_vocab_and_stcm_tables()
 
 This will temporarily disable foreign keys on the STCM tables, allowing custom vocabularies to be
-replaced if still referenced from there.
-Otherwise, they can be loaded independently:
+replaced if still referenced from there. Otherwise, they can be loaded independently:
 
 .. code-block:: python
 
    self.vocab_manager.custom_vocabularies.load()
 
-
 Versioning
 ----------
 Like standard vocabularies, custom vocabularies need to have a version as provided in the
-vocabulary_version field of the vocabulary table. If the provided version value is different
-than what is currently loaded in the database (if anything), the vocabulary will be replaced with
+``vocabulary_version`` field of the VOCABULARY table. If the provided version value is different
+from what is currently loaded in the database (if anything), the vocabulary will be replaced with
 the new version.

--- a/docs/custom_vocab.rst
+++ b/docs/custom_vocab.rst
@@ -9,8 +9,10 @@ Custom Vocabulary files
 -----------------------
 
 Non-standard vocabulary data can be provided as tab-delimited (tsv) files.
-The file names must end with the name of the vocabulary table they should be inserted in
+The file names must end with the name of the vocabulary table they should be inserted into
 (e.g. concept.tsv). File name matching is case-insensitive.
+Each file is expected to contain a header with field names matching the column names
+of the database table the file maps to (in lowercase).
 Currently, target tables CONCEPT, CONCEPT_CLASS, and VOCABULARY are supported.
 
 The custom vocabulary files may contain data from one or more custom vocabularies.
@@ -35,6 +37,8 @@ Files have to be placed in te following folder:
                 ├── MYVOCAB_concept.tsv
                 ├── MYVOCAB_concept_class.tsv
                 ├── MYVOCAB_vocabulary.tsv
+                ├── mixed_concept.tsv
+                ├── mixed_concept_class.tsv
                 ├── mixed_vocabulary.tsv
                 └── etc.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,8 @@ delphyne
    transformations
    standard_vocab
    custom_vocab
-   code_mapper
+   stcm
+   semantic_mapping
    reference
    changelog_link
 

--- a/docs/semantic_mapping.rst
+++ b/docs/semantic_mapping.rst
@@ -14,13 +14,13 @@ Delphyne's :class:`.CodeMapper` class enables the creation of mapping dictionari
 terms to valid standard concept_ids. Once created, a mapping dictionary can be used in any transformation to quickly
 lookup mappings for any source term.
 
-Mappings are built on information extracted from the CONCEPT and CONCEPT_RELATIONSHIP tables.
-For example, it is possible to automatically map ICD10CM ontology terms to their SNOMED standard concept_id equivalent;
-the only prerequisite is to have both vocabularies loaded to your database (including CONCEPT_RELATIONSHIP information).
+Mappings are built on information extracted from the CONCEPT and CONCEPT_RELATIONSHIP tables. For example, it is
+possible to automatically extract mappings from ICD10CM ontology terms to their equivalent standard concept_id
+(typically SNOMED).
 
 Note that creating a mapping dictionary with this method is only possible for **official OMOP vocabularies**;
 if a source vocabulary is not available from `Athena <https://athena.ohdsi.org/vocabulary/list>`_,
-other mapping methods should be considered.
+alternative methods should be considered.
 
 Creating a mapping dictionary
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/semantic_mapping.rst
+++ b/docs/semantic_mapping.rst
@@ -5,12 +5,12 @@ Semantic mapping tools
     :local:
     :backlinks: none
 
-The section describes available Delphyne's tools to map source data to standard OMOP concept_ids during ETL execution.
+The section describes available delphyne's tools to map source data to standard OMOP concept_ids during ETL execution.
 
 Vocabulary-based mappings
 -------------------------
 
-Delphyne's :class:`.CodeMapper` class enables the creation of mapping dictionaries from non-standard OMOP vocabulary
+delphyne's :class:`.CodeMapper` class enables the creation of mapping dictionaries from non-standard OMOP vocabulary
 terms to valid standard concept_ids. Once created, a mapping dictionary can be used in any transformation to quickly
 lookup mappings for any source term.
 

--- a/docs/semantic_mapping.rst
+++ b/docs/semantic_mapping.rst
@@ -1,25 +1,26 @@
-Semantic mapping
-================
+Semantic mapping tools
+======================
 
 .. contents::
     :local:
     :backlinks: none
 
-The section describes available Delphyne's methods to map source data to standard OMOP concept_ids.
+The section describes available Delphyne's tools to map source data to standard OMOP concept_ids during ETL execution.
 
-CodeMapper
-----------
+Vocabulary-based mappings
+-------------------------
 
-Delphyne's :class:`.CodeMapper` class enables the creation
-of mapping dictionaries from non-standard OMOP vocabulary terms to valid standard concept_ids.
+Delphyne's :class:`.CodeMapper` class enables the creation of mapping dictionaries from non-standard OMOP vocabulary
+terms to valid standard concept_ids. Once created, a mapping dictionary can be used in any transformation to quickly
+lookup mappings for any source term.
+
 Mappings are built on information extracted from the CONCEPT and CONCEPT_RELATIONSHIP tables.
-For example, it is possible to automatically map ICD10CM ontology terms to their SNOMED standard concept_id equivalent.
-Once created, a mapping dictionary can be used in any transformation to quickly lookup target concept_id information
-for any source term.
+For example, it is possible to automatically map ICD10CM ontology terms to their SNOMED standard concept_id equivalent;
+the only prerequisite is to have both vocabularies loaded to your database (including CONCEPT_RELATIONSHIP information).
 
-Note that creating a mapping dictionary with this method is only possible for official OMOP vocabularies;
+Note that creating a mapping dictionary with this method is only possible for **official OMOP vocabularies**;
 if a source vocabulary is not available from `Athena <https://athena.ohdsi.org/vocabulary/list>`_,
-other mapping methods should be considered (e.g. loading the mappings directly from file).
+other mapping methods should be considered.
 
 Creating a mapping dictionary
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -29,8 +30,8 @@ for one or multiple source vocabularies at once, identified by their OMOP vocabu
 When possible, it is recommended to use the ``restrict_to_codes`` argument to load mappings
 only for the source codes that will be actually used in the transformations, thus limiting memory usage.
 
-Delphyne's :class:`.Wrapper` class provides a ready-to-use :class:`.CodeMapper` instance under
-the attribute ``code_mapper``. You can use it to create a mapping dictionary inside a transformation script as follows:
+Delphyne's :class:`.Wrapper` class provides a ready-to-use :class:`.CodeMapper` instance under the attribute
+``self.code_mapper``. You can use it to create a mapping dictionary inside a transformation script as follows:
 
 .. code-block:: python
 
@@ -78,3 +79,21 @@ a single :class:`.CodeMapping` object with both ``source_concept_id`` and ``targ
 
 Use the option ``target_concept_id_only=True`` to retrieve a list of ``target_concept_id`` instead of full mapping objects.
 Use ``first_only=True`` to retrieve the first available match instead of a list of all matches.
+
+STCM mappings
+-------------
+
+The :class:`.Wrapper` class provides a :meth:`~.Wrapper.lookup_stcm()` method to extract mappings from the
+SOURCE_TO_CONCEPT_MAP table. Note that you will need to populate the table yourself before being able to use this
+method (see :ref:`Source to concept map` for instructions).
+
+Looking up STCM mappings
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can lookup mapping information for a single source code at a time as follows:
+
+.. code-block:: python
+
+   mapping = wrapper.lookup_stcm(source_vocabulary_id='MY_VOCAB', source_code='ABC')
+
+The result is a single standard OMOP concept_id, or ``0`` if nothing is found.

--- a/docs/standard_vocab.rst
+++ b/docs/standard_vocab.rst
@@ -36,8 +36,8 @@ the standard vocabularies folder:
 Add to pipeline
 ---------------
 
-Make sure the `skip_vocabulary_loading` option in your config.yml is set to False.
-As part of your Wrapper's run method, the following line must be included.
+Make sure the ``skip_vocabulary_loading`` option in your config.yml is set to ``False``.
+As part of your Wrapper's run method, the following line must be included:
 
 .. code-block:: python
 
@@ -53,6 +53,6 @@ Limitations
 -----------
 
 As SQL Server's bulk insert method requires a local file path, it can only be used if you're running
-delphyne in the same environment as the database.
+Delphyne in the same environment as the database.
 To insert the vocabularies manually, you can find instructions in
 the `CommonDataModel repository <https://github.com/OHDSI/CommonDataModel>`_.

--- a/docs/standard_vocab.rst
+++ b/docs/standard_vocab.rst
@@ -53,6 +53,6 @@ Limitations
 -----------
 
 As SQL Server's bulk insert method requires a local file path, it can only be used if you're running
-Delphyne in the same environment as the database.
+delphyne in the same environment as the database.
 To insert the vocabularies manually, you can find instructions in
 the `CommonDataModel repository <https://github.com/OHDSI/CommonDataModel>`_.

--- a/docs/stcm.rst
+++ b/docs/stcm.rst
@@ -117,7 +117,7 @@ this relationship is captured in the SOURCE_TO_CONCEPT_MAP_VERSION table.
 When you update the mapping version for a given ``source_vocabulary_id`` in the ``stcm_versions.tsv`` file,
 this will update the SOURCE_TO_CONCEPT_MAP_VERSION table, and cause all SOURCE_TO_CONCEPT_MAP records associated with
 that vocabulary to be dropped and replaced with new records from the provided STCM files, if any.
-If you completely remove a ``source_vocabulary_id`` from ``stcm_versions.tsv``, associated records will also be dropped.
+If you remove a ``source_vocabulary_id`` from ``stcm_versions.tsv``, associated records will also be dropped.
 
 .. note::
    The SOURCE_TO_CONCEPT_MAP_VERSION table is not part of the standard OMOP CDM. We specifically introduced it in our

--- a/docs/stcm.rst
+++ b/docs/stcm.rst
@@ -1,0 +1,81 @@
+Source to concept map
+=====================
+
+.. contents::
+    :local:
+    :backlinks: none
+
+The section describes available Delphyne's methods to map source data to standard OMOP concept_ids.
+
+STCM files
+----------
+
+Non-standard vocabulary data can be provided as tab-delimited (tsv) files.
+The file names must end with the name of the vocabulary table they should be inserted in (e.g. concept.tsv).
+Currently, target tables concept, concept_class and vocabulary are supported.
+
+The custom vocabulary files may contain data of one or more custom vocabularies.
+When a vocabulary file contains data of only one custom vocabulary,
+it's good practice to prepend the vocabulary_id to the file name (e.g. MYVOCAB_concept.tsv).
+This way, if the vocabulary version hasn't changed (see `Versioning`_),
+the file will be ignored without needing to parse the file contents.
+
+For custom vocabularies, the vocabulary_concept_id (vocabulary) and
+concept_class_concept_id (concept_class) should always be set to 0.
+
+Files have to be placed in te following folder:
+
+::
+
+    project_root
+    └── resources
+        └── vocabularies
+            └── source_to_concept_map
+                ├── MYVOCAB_stcm.tsv
+                ├── mixed_vocabs_stcm.tsv
+                ├── stcm_versions.tsv
+                └── etc.
+
+Make sure to add any custom vocabulary used in the stcm tables to the custom vocabulary folder
+(see :ref:`Custom Vocabulary files`).
+
+Add to pipeline
+---------------
+
+Make sure the ``skip_source_to_concept_map_loading`` option in your config.yml file is set to ``False``.
+
+To load STCM files during ETL execution, add the following call to your Wrapper's run method:
+
+.. code-block:: python
+
+   self.vocab_manager.stcm.load()
+
+If you are loading **custom vocabularies associated with the STCM records**
+(typically the case when loading STCM tables for the first time),
+also set ``skip_custom_vocabulary_loading`` to ``False`` in config.yml,
+and replace the previous call with the following in the Wrapper's run method:
+
+.. code-block:: python
+
+   self.vocab_manager.load_custom_vocab_and_stcm_tables()
+
+Versioning
+----------
+STCM records are always associated with a mapping version (``stcm_version``) through their ``source_vocabulary_id``;
+this relationship is captured in the SOURCE_TO_CONCEPT_MAP_VERSION table.
+
+When you update the mapping version for a given ``source_vocabulary_id`` in the ``stcm_versions.tsv`` file,
+this will update the SOURCE_TO_CONCEPT_MAP_VERSION table, and cause all SOURCE_TO_CONCEPT_MAP records associated with
+that vocabulary to be dropped and replaced with new records from the ``source_to_concept_map`` folder, if any.
+
+STCM tables cleanup
+-------------------
+
+To wipe clean both the SOURCE_TO_CONCEPT_MAP and SOURCE_TO_CONCEPT_MAP_VERSION tables,
+use the :meth:`~.StcmLoader.delete()` call in the Wrapper's run method:
+
+.. code-block:: python
+
+   self.vocab_manager.stcm.delete()
+
+You can optionally pass a ``vocab_ids`` parameter containing a set of ``source_vocabulary_id`` to be removed selectively.

--- a/docs/stcm.rst
+++ b/docs/stcm.rst
@@ -22,8 +22,11 @@ it's good practice to prepend the vocabulary_id to the file name (e.g. MYVOCAB_s
 This way, if the mapping version associated with that vocabulary hasn't changed (see `Versioning`_),
 the file will be ignored without needing to parse the file contents.
 
-Below is an **STCM file example**; in addition to the fields shown, it should contain
-``valid_start_date``, ``valid_end_date`` (mandatory), and ``source_code_description``, ``invalid_reason`` (optional):
+Each STCM file is expected to contain a header with field names matching the column names
+of the SOURCE_TO_CONCEPT_MAP table (in lowercase).
+Below is an **STCM file example**; in addition to the fields shown, it must contain
+``valid_start_date``, ``valid_end_date`` (value is mandatory),
+and ``source_code_description``, ``invalid_reason`` (value is optional):
 
 .. list-table:: mixed_vocabs_stcm.csv
    :widths: auto
@@ -50,8 +53,9 @@ The ``source_concept_id`` field should be set to ``0`` or a custom concept_id ab
 in the latter case, make sure to load the corresponding CONCEPT records to the vocabulary tables
 (see instructions in :ref:`Custom vocabularies`).
 
-In addition to STCM files, you must also provide a single tab-separated file named **stcm_versions.tsv**.
-This file is needed for the versioning of STCM records (see `Versioning`_).
+In addition to STCM files, you must always provide a single tab-separated file named **stcm_versions.tsv**,
+containing the header fields shown below (in lowercase). This file maps to the SOURCE_TO_CONCEPT_MAP_VERSION table
+and is needed for the versioning of STCM records (see `Versioning`_).
 
 .. list-table:: stcm_versions.tsv
    :widths: auto
@@ -88,9 +92,8 @@ Make sure to add any custom vocabulary used in the stcm tables to the custom voc
 Add to pipeline
 ---------------
 
-Make sure the ``skip_source_to_concept_map_loading`` option in your config.yml file is set to ``False``.
-
-To load STCM files, add the following call to your Wrapper's run method:
+To load STCM files, set the ``skip_source_to_concept_map_loading`` option in your config.yml to ``False``,
+and add the following call to your Wrapper's run method:
 
 .. code-block:: python
 
@@ -107,12 +110,14 @@ and replace the previous call with the following in the Wrapper's run method:
 
 Versioning
 ----------
+
 STCM records are always associated with a mapping version (``stcm_version``) through their ``source_vocabulary_id``;
 this relationship is captured in the SOURCE_TO_CONCEPT_MAP_VERSION table.
 
 When you update the mapping version for a given ``source_vocabulary_id`` in the ``stcm_versions.tsv`` file,
 this will update the SOURCE_TO_CONCEPT_MAP_VERSION table, and cause all SOURCE_TO_CONCEPT_MAP records associated with
 that vocabulary to be dropped and replaced with new records from the provided STCM files, if any.
+If you completely remove a ``source_vocabulary_id`` from ``stcm_versions.tsv``, associated records will also be dropped.
 
 .. note::
    The SOURCE_TO_CONCEPT_MAP_VERSION table is not part of the standard OMOP CDM. We specifically introduced it in our


### PR DESCRIPTION
Fixes #123 

In the end for the structure I went like this:
- STCM loading in its own section, as for standard & custom vocabularies
- STCM mappings (which is actually a separate lookup provided by the Wrapper, not StcmLoader) in the Semantic mapping tools

Also cleaned up some things along the way.