### PR TITLE
Docs fixes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,6 +25,7 @@ autodoc_default_options = {
 
 add_module_names = False
 autosummary_generate = True
+autosectionlabel_prefix_document =  True
 autodoc_typehints = 'description'
 
 # html_theme = "sphinx_rtd_theme"

--- a/docs/semantic_mapping.rst
+++ b/docs/semantic_mapping.rst
@@ -85,7 +85,7 @@ STCM mappings
 
 The :class:`.Wrapper` class provides a :meth:`~.Wrapper.lookup_stcm()` method to extract mappings from the
 SOURCE_TO_CONCEPT_MAP table. Note that you will need to populate the table yourself before being able to use this
-method (see :ref:`Source to concept map` for instructions).
+method (see :ref:`stcm:Source to concept map` for instructions).
 
 Looking up STCM mappings
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/stcm.rst
+++ b/docs/stcm.rst
@@ -7,7 +7,7 @@ Source to concept map
 
 The SOURCE_TO_CONCEPT_MAP (STCM) table is a legacy vocabulary table that allows to store mappings from
 source codes to standard OMOP concept_ids. Aside from documenting semantic mapping choices inside your database,
-it can be conveniently used for lookups during the ETL process - see :ref:`STCM mappings` for details.
+it can be conveniently used for lookups during the ETL process - see :ref:`semantic_mapping:STCM mappings` for details.
 
 STCM files
 ----------
@@ -51,7 +51,7 @@ and ``source_code_description``, ``invalid_reason`` (value is optional):
 
 The ``source_concept_id`` field should be set to ``0`` or a custom concept_id above 2 billion;
 in the latter case, make sure to load the corresponding CONCEPT records to the vocabulary tables
-(see instructions in :ref:`Custom vocabularies`).
+(see instructions in :ref:`custom_vocab:Custom vocabularies`).
 
 In addition to STCM files, you must always provide a single tab-separated file named **stcm_versions.tsv**,
 containing the header fields shown below (in lowercase). This file maps to the SOURCE_TO_CONCEPT_MAP_VERSION table
@@ -87,7 +87,7 @@ Files have to be placed in te following folder:
    because this is currently the STCM export format provided by Usagi.
 
 Make sure to add any custom vocabulary used in the stcm tables to the custom vocabulary folder
-(see :ref:`Custom Vocabulary files`).
+(see :ref:`custom_vocab:Custom Vocabulary files`).
 
 Add to pipeline
 ---------------

--- a/src/delphyne/database/database.py
+++ b/src/delphyne/database/database.py
@@ -44,8 +44,6 @@ class Database:
 
     Attributes
     ----------
-    schemas
-    reflected_metadata
     engine : sqlalchemy.engine.base.Engine
         Database engine.
     constraint_manager : ConstraintManager


### PR DESCRIPTION
@Spayralbe I was annoyed with sphinx warnings so I fixed some things.. I'm not sure about the `Database` docstring changes, pls check (in the documentation it still shows correctly `schemas` & `reflected_metadata` as properties, so I guess they were not needed in `Attributes` after all?)