### PR TITLE
Remove separate database_exists check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ setup(
         "psycopg2-binary >= 2.8, <3",
         "pydantic >= 1.7, <2",
         "SQLAlchemy >= 1.3, <1.4",
-        "SQLAlchemy-Utils >= 0.36, <1",
         "pandas >= 1.0.5, <2",
         "PyYAML >= 5.4, <6",
     ],
@@ -47,7 +46,7 @@ setup(
     package_dir={"": "src"},
     packages=["delphyne"],
     extras_require={
-        "TEST": ["pytest", "pytest-cov", "docker", "nox", "flake8"],
+        "TEST": ["pytest", "pytest-cov", "SQLAlchemy-Utils", "docker", "nox", "flake8"],
     },
     url="https://github.com/thehyve/delphyne",
     version=version['__version__'],

--- a/src/delphyne/database/constraints/constraint_manager.py
+++ b/src/delphyne/database/constraints/constraint_manager.py
@@ -72,11 +72,14 @@ class _DbCheckConstraints:
     # these for the dialect in use.
     def __init__(self, database: Database):
         self._db = database
-        self.chk_support = self._check_reflection_support()
-
         self._dialect_method_lookup = {
             'mssql': self._get_chk_constraints_mssql
         }
+
+    @property
+    @lru_cache()
+    def chk_support(self) -> bool:
+        return self._check_reflection_support()
 
     @property
     @lru_cache()

--- a/src/delphyne/wrapper.py
+++ b/src/delphyne/wrapper.py
@@ -46,7 +46,7 @@ class Wrapper(OrmWrapper, RawSqlWrapper):
         self._config = config
         self.db = Database.from_config(config, cdm_.Base)
 
-        if not self.db.can_connect(str(self.db.engine.url)):
+        if not self.db.can_connect(self.db.engine.url):
             sys.exit()
 
         super().__init__(database=self.db)

--- a/tests/python/wrapper/test_wrapper.py
+++ b/tests/python/wrapper/test_wrapper.py
@@ -10,17 +10,11 @@ pytestmark = pytest.mark.skipif(condition=docker_not_available(),
 
 
 @pytest.mark.usefixtures("container")
-def test_db_does_not_exist(db_config, caplog):
-    uri = f'postgresql://postgres:secret@localhost:{db_config.port}/foobar'
-    assert not Database.can_connect(uri)
-    assert 'Database "foobar" does not exist' in caplog.text
-
-
-@pytest.mark.usefixtures("container")
-def test_connection_invalid(caplog):
-    uri = 'postgresql://postgres:secret@localhost:123456/postgres'
-    assert not Database.can_connect(uri)
-    assert 'Database "postgres" does not exist' not in caplog.text
+def test_connection_invalid(db_config):
+    invalid_port_uri = 'postgresql://postgres:secret@localhost:123456/postgres'
+    assert not Database.can_connect(invalid_port_uri)
+    invalid_db_uri = f'postgresql://postgres:secret@localhost:{db_config.port}/foobar'
+    assert not Database.can_connect(invalid_db_uri)
 
 
 @pytest.mark.usefixtures("test_db_module")


### PR DESCRIPTION
Since SQLALchemy-Utils version 0.37 there is no a longer a distinction between invalid connections and non-existing databases when calling `database_exists`. Therefore the connection testing logic is now simplified a bit and the logger will just show the original error in case a database connection could not be established.

Makes SQLALchemy-Utils a test-only dependency.