### PR TITLE
Support multiple STCM targets

### DIFF
--- a/docs/semantic_mapping.rst
+++ b/docs/semantic_mapping.rst
@@ -94,6 +94,10 @@ You can lookup mapping information for a single source code at a time as follows
 
 .. code-block:: python
 
-   mapping = wrapper.lookup_stcm(source_vocabulary_id='MY_VOCAB', source_code='ABC')
+   mapping = wrapper.code_mapper.lookup_stcm(source_vocabulary_id='MY_VOCAB', source_code='ABC')
 
-The result is a single standard OMOP concept_id, or ``0`` if nothing is found.
+The result is a tuple containing one or multiple target_concept_id values if available.
+If no target_concept_id could be found for the provided source_code, an empty tuple is returned.
+
+.. note::
+   STCM lookups are cached, meaning that recurrent lookups will not require a database query.

--- a/docs/semantic_mapping.rst
+++ b/docs/semantic_mapping.rst
@@ -83,7 +83,7 @@ Use ``first_only=True`` to retrieve the first available match instead of a list 
 STCM mappings
 -------------
 
-The :class:`.Wrapper` class provides a :meth:`~.Wrapper.lookup_stcm()` method to extract mappings from the
+The :class:`.CodeMapper` class provides a :meth:`~.CodeMapper.lookup_stcm()` method to extract mappings from the
 SOURCE_TO_CONCEPT_MAP table. Note that you will need to populate the table yourself before being able to use this
 method (see :ref:`stcm:Source to concept map` for instructions).
 

--- a/src/delphyne/model/orm_wrapper.py
+++ b/src/delphyne/model/orm_wrapper.py
@@ -4,7 +4,6 @@ import logging
 import os
 from abc import ABC, abstractmethod
 from collections import Counter
-from functools import lru_cache
 from inspect import signature
 from typing import Callable, List
 
@@ -171,29 +170,3 @@ class OrmWrapper(ABC):
         transformation_metadata.deletion_counts = dc
         ic = Counter(events.get_record_targets(records_to_insert))
         transformation_metadata.insertion_counts = ic
-
-    @lru_cache(maxsize=50000)
-    def lookup_stcm(self, source_vocabulary_id: str, source_code: str) -> int:
-        """
-        Query the STCM table to get the target_concept_id.
-
-        Parameters
-        ----------
-        source_vocabulary_id : str
-            Vocabulary ID of the source code.
-        source_code : str
-            Code belonging to the source vocabulary for which to look up
-            the mapping.
-
-        Returns
-        -------
-        int
-            Target_concept_id if present, otherwise 0.
-        """
-        with self.db.session_scope() as session:
-            q = session.query(self.cdm.SourceToConceptMap)
-            result = q.filter_by(source_vocabulary_id=source_vocabulary_id,
-                                 source_code=source_code).one_or_none()
-            if result is None:
-                return 0
-            return result.target_concept_id


### PR DESCRIPTION
Fixes #173 

- Return STCM lookup results as a tuple, that can contain zero, one or multiple target_concept_id values
- Move the lookup method to the `CodeMapper` class
- Update STCM lookup docs